### PR TITLE
Add error check / promise rejection for RCTGtm

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,15 +2,17 @@
 
 import { NativeModules } from 'react-native';
 
-var RCTGtm = NativeModules.ReactNativeGtm;
+const RCTGtm = NativeModules.ReactNativeGtm;
 
-var ReactNativeGtm = {
+const ReactNativeGtm = {
      /**
      * Creating a ContainerHolder Singleton
      * @param {String} containerId
      */
     openContainerWithId : function(containerId) {
-        return RCTGtm.openContainerWithId(containerId);
+        return (RCTGtm) ? RCTGtm.openContainerWithId(containerId) : new Promise((resolve,reject) => {
+            reject(new Error('RCTGtm not found'));
+        });
     },
     /**
      * Merges the given <code>json</code> object into the existing data model,


### PR DESCRIPTION
This update is checking whether RCTGtm is linked correctly. If not, it returns a rejected promise with error message.

There are two cases this is meant to solve:
1. developer has linked RCTGtm incorrectly in the project
2. (mocha) tests can now handle NativeModules import properly without extra effort